### PR TITLE
Add direct installation link (no URL shortener) and supported video formats, to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,10 @@
 ## Installation
 
 ```sh
-sudo su -c "bash <(wget -qO- [https://cutt.ly/PjNkrzq](https://raw.githubusercontent.com/jschmid1/gopro_as_webcam_on_linux/master/install.sh))" root
+sudo su -c "bash <(wget -qO- https://cutt.ly/PjNkrzq)" root
 ```
+
+(If you're unable to access the shortened link, use the following: `https://raw.githubusercontent.com/jschmid1/gopro_as_webcam_on_linux/master/install.sh` )
 
 This runs an install script. Follow the instructions on the screen.
 
@@ -71,6 +73,16 @@ Options:
 Commands:
   webcam                   start the GoPro in webcam mode
 
+```
+
+## Formats supported
+
+After launched in webcam mode, the device only supports one format:
+
+```
+	[0]: 'YU12' (Planar YUV 4:2:0)
+		Size: Discrete 1920x1080
+			Interval: Discrete 0.033s (30.000 fps)
 ```
 
 ## Examples

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Use your GoPro as a webcam on Linux (without additional hardware)
-> Currently there is no official support for using your GoPro 8&9 (the only versions that offer this feature natively) as a webcam on Linux. The web is full of incomplete tutorials for this topic. This script tries to simplify this effort.
+> Currently there is no official support for using your GoPro 8, 9, or 10 (the only versions that offer this feature natively) as a webcam on Linux. The web is full of incomplete tutorials for this topic. This script tries to simplify this effort.
 
 ## Installation
 
 ```sh
-sudo su -c "bash <(wget -qO- https://cutt.ly/PjNkrzq)" root
+sudo su -c "bash <(wget -qO- [https://cutt.ly/PjNkrzq](https://raw.githubusercontent.com/jschmid1/gopro_as_webcam_on_linux/master/install.sh))" root
 ```
 
 This runs an install script. Follow the instructions on the screen.


### PR DESCRIPTION
My web filter blocks most URL shorteners like bit.ly or cutt.ly, and many others -- I'm sure there are other people with the same limitation as well.

This change replaces the URL shortened link with the link it points to, which won't change unless you change your username or rename the repository.

I also updated the documentation to point out that it works with the GoPro 10 as well (since it only specified 8 or 9).