### PR TITLE
Fix: gracefully handle v4l2loopback module in use

### DIFF
--- a/gopro
+++ b/gopro
@@ -292,18 +292,21 @@ function test_module_unload {
         green "${module} was unloaded successfully."
         return 0
     else
-        red "${module} could not be unloaded. There is maybe an ffmpeg(or similar) running that uses this module"
-        exit 1
+        return 1
     fi
 
 }
 
-function test_module_loaded { 
+function test_module_loaded {
     # test if module is already loaded
     if lsmod | grep ${module} &> /dev/null ; then
         green "${module} is loaded!"
-        test_module_unload
-        return 0
+        if test_module_unload 2>/dev/null; then
+            return 0
+        else
+            yellow "${module} is in use, skipping reload (device already exists)."
+            return 0
+        fi
     else
         green "${module} is not loaded!"
         return 1


### PR DESCRIPTION
## Summary
- `test_module_unload` now returns `1` instead of `exit 1` when the module can't be unloaded
- `test_module_loaded` gracefully skips module reload when it's in use by another application (e.g., OBS)
- This allows restarting the webcam stream without closing all applications that use `/dev/video42`

## Problem
When `v4l2loopback` is in use by another application (like OBS), the script exits with an error. Users are forced to close all video applications before restarting the webcam, which is disruptive.

## Test plan
- [ ] Start webcam with `sudo gopro webcam -a -n`
- [ ] Open OBS and add `/dev/video42` as source
- [ ] Stop and restart the webcam — should work without closing OBS
- [ ] Verify normal startup (no OBS) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)